### PR TITLE
Upgrade npm because prev ver had expired hardcoded certs so was failing.

### DIFF
--- a/apache-php/7.0/Dockerfile
+++ b/apache-php/7.0/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER pica9
 # add additional repos
 RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+RUN curl -sL https://rpm.nodesource.com/setup_8.x | bash -
 
 # install apache, php5
 RUN yum install -y --enablerepo=remi --enablerepo=remi-php70 \
@@ -31,7 +32,7 @@ RUN yum install -y --enablerepo=remi --enablerepo=remi-php70 \
     libcurl-devel \
     git \
     java-1.7.0-openjdk \
-    npm \
+    nodejs \
     mod_ssl \
     tar \
     libssh2 \

--- a/apache-php/7.1/Dockerfile
+++ b/apache-php/7.1/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER pica9
 # add additional repos
 RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+RUN curl -sL https://rpm.nodesource.com/setup_8.x | bash -
 
 # install apache, php5
 RUN yum install -y --enablerepo=remi --enablerepo=remi-php71 \
@@ -31,7 +32,7 @@ RUN yum install -y --enablerepo=remi --enablerepo=remi-php71 \
     libcurl-devel \
     git \
     java-1.7.0-openjdk \
-    npm \
+    nodejs \
     mod_ssl \
     tar \
     libssh2 \


### PR DESCRIPTION
Test plan is attached to related campaign-drive PR here:

https://github.com/Pica9/campaign-drive/pull/73

Images have already been built and pushed as 7.0.1 and 7.1.1.